### PR TITLE
Implement board state validation for moves

### DIFF
--- a/Src/LChess.Service/Game/ChessGameService.cs
+++ b/Src/LChess.Service/Game/ChessGameService.cs
@@ -1,6 +1,8 @@
 ﻿using LChess.Abstract.Service;
 
 using LChess.Models.Result;
+using System.Collections.Generic;
+using System.Text;
 
 namespace LChess.Service.Game;
 
@@ -14,11 +16,11 @@ public class ChessGameService : IChessGameService
 	/// <summary>
 	/// 생성자
 	/// </summary>
-	public ChessGameService(IStockfishEngineService stockfishEngineService)
-	{
-		_stockfishEngineService = stockfishEngineService;
+        public ChessGameService(IStockfishEngineService stockfishEngineService)
+        {
+                _stockfishEngineService = stockfishEngineService;
 
-		_notations = new Queue<string>();
+                _notations = new List<string>();
     }
 
 	#endregion
@@ -37,7 +39,12 @@ public class ChessGameService : IChessGameService
 	/// <summary>
 	/// 기물 움직임 기보
 	/// </summary>
-	private Queue<string> _notations;
+        private List<string> _notations;
+
+        /// <summary>
+        /// 직전 보드 상태
+        /// </summary>
+        private StockfishBoardCodeModel? _previousBoard;
 
     #endregion
 
@@ -49,10 +56,11 @@ public class ChessGameService : IChessGameService
     public async Task<StockfishBoardCodeModel?> NewGame()
     {
         _notations.Clear();
-		await _stockfishEngineService.StartEngineAsync();
+                await _stockfishEngineService.StartEngineAsync();
         await _stockfishEngineService.SendCommandAsync("position startpos", string.Empty);
 
-        return await _stockfishEngineService.GetCurrentBoard();
+        _previousBoard = await _stockfishEngineService.GetCurrentBoard();
+        return _previousBoard;
     }
 
     /// <summary>
@@ -75,8 +83,8 @@ public class ChessGameService : IChessGameService
 	{
         if (string.IsNullOrEmpty(notation) || notation.Contains("none")) return null;
 
-		// 기보 저장
-		_notations.Enqueue(notation);
+                // 기보 저장
+                _notations.Add(notation);
 
 		StringBuilder commandBuilder = new StringBuilder("position startpos moves");
 
@@ -85,9 +93,20 @@ public class ChessGameService : IChessGameService
             commandBuilder.Append($" {history}");
         }
 
-		await _stockfishEngineService.SendCommandAsync(commandBuilder.ToString(), string.Empty);
+                await _stockfishEngineService.SendCommandAsync(commandBuilder.ToString(), string.Empty);
 
         var result = await _stockfishEngineService.GetCurrentBoard();
+
+        // 보드 상태가 변하지 않았으면 마지막 기보를 삭제하고 null 반환
+        if (_previousBoard != null && IsSameBoard(_previousBoard, result))
+        {
+            if (_notations.Count > 0)
+                _notations.RemoveAt(_notations.Count - 1);
+
+            return null;
+        }
+
+        _previousBoard = result;
 
         return result;
     }
@@ -96,11 +115,28 @@ public class ChessGameService : IChessGameService
     /// AI가 판단하는 BestMove 획득
     /// </summary>
     /// <returns> BestMove 처리결과 </returns>
-	public async Task<StockfishBestMoveModel> BestMove()
+    public async Task<StockfishBestMoveModel> BestMove()
     {
         var bestMove = await _stockfishEngineService.SendCommandAsync("go depth 20", "best");
 
         return new StockfishBestMoveModel(bestMove?.Split(' ').ElementAt(1) ?? "(none)");
+    }
+
+    /// <summary>
+    /// 두 보드 상태가 동일한지 비교
+    /// </summary>
+    private static bool IsSameBoard(StockfishBoardCodeModel a, StockfishBoardCodeModel b)
+    {
+        if (a.TileCodeList.Count != b.TileCodeList.Count)
+            return false;
+
+        for (int i = 0; i < a.TileCodeList.Count; i++)
+        {
+            if (a.TileCodeList[i] != b.TileCodeList[i])
+                return false;
+        }
+
+        return true;
     }
 
     #endregion

--- a/Src/LChess.ViewModels/DataContext/Contents/ChessBoardContentViewModel.cs
+++ b/Src/LChess.ViewModels/DataContext/Contents/ChessBoardContentViewModel.cs
@@ -201,6 +201,9 @@ public partial class ChessBoardContentViewModel : ObservableRecipient, IContentV
                     var userMoveResult = await _chessGameService.MovePiece(notation);
                     BoardModel.ParseCodes(userMoveResult);
 
+                    if (userMoveResult == null)
+                        return;
+
                     var bestMoveResult = await _chessGameService.BestMove();
                     if (CheckEndGame(userMoveResult, bestMoveResult)) return;
                 }


### PR DESCRIPTION
## Summary
- track previous board state in ChessGameService
- remove last notation when Stockfish board state doesn't change
- skip AI turn when the player made an invalid move

## Testing
- `dotnet build Src/LChess.sln` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_687dfa95c2a08329aa1e658c5fe54ff3